### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,10 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.6"
+    },
+    "autoload": {
+        "psr-4": {
+            "OpenSwoole\\": "src/OpenSwoole/"
+        }
     }
 }


### PR DESCRIPTION
Added autoload to composer.json for better compatibility with PHPStan.

PHPStan was throwing errors due to missing autoload configuration in the composer.json file. This pull request addresses that issue by including autoload configuration.